### PR TITLE
build(python): relax version constraints for shared REANA modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "reana-commons==0.95.0a9",
-    "reana-db==0.95.0a5"
+    "reana-commons>=0.95.0a9,<0.96.0",
+    "reana-db>=0.95.0a5,<0.96.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ cryptography==44.0.3      # via sqlalchemy-utils
 fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
 gherkin-official==32.0.0  # via reana-commons
-greenlet==3.2.1           # via sqlalchemy
 idna==3.10                # via jsonschema, requests
 importlib-resources==6.5.2  # via swagger-spec-validator
 isoduration==20.11.0      # via jsonschema


### PR DESCRIPTION
Changes dependency constraints to allow all `reana-commons` and `reana-db` 0.95.x versions, enabling notably compatibility with newly released `reana-commons` 0.95.0a10.