### PR TITLE
ci(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install dask-kubernetes
           pip install .[test]


### PR DESCRIPTION
Pin setuptools<81 in CI workflows. This is because the
recent setuptools 81.0.0 upgrade removed the
pkg_resources module that is needed at runtime by some
dependencies.