### PR TITLE
fix(dask): persist service logs on pod termination

### DIFF
--- a/reana_dask_kubernetes_operator/watcher.py
+++ b/reana_dask_kubernetes_operator/watcher.py
@@ -10,6 +10,7 @@
 
 import logging
 import kopf
+from kubernetes.client.rest import ApiException
 
 from reana_commons.k8s.api_client import current_k8s_corev1_api_client
 from reana_commons.utils import get_dask_component_name
@@ -24,25 +25,13 @@ from reana_dask_kubernetes_operator.utils import extract_component_name_from_pod
 
 logging.info("REANA Dask Kubernetes Operator watcher module loaded.")
 
-if not REANA_OPENSEARCH_ENABLED:
+if not REANA_OPENSEARCH_ENABLED:  # noqa: C901
 
-    @kopf.on.create("v1", "pods", labels={"dask.org/component": "scheduler"})
-    @kopf.on.create("v1", "pods", labels={"dask.org/component": "worker"})
-    def add_finalizer(name, meta, patch, logger, **_):
-        """Add a finalizer when a Dask pod is created."""
-        try:
-            logger.info(f"Adding finalizer to pod {name}")
-            finalizers = meta.get("finalizers", [])
-            if DASK_PODS_FINALIZER_NAME not in finalizers:
-                finalizers.append(DASK_PODS_FINALIZER_NAME)
-                patch.metadata["finalizers"] = finalizers
-        except Exception as e:
-            logger.error(f"Error adding finalizer to pod {name}: {e}")
+    def _store_pod_logs(name, meta, namespace, logger):
+        """Store Dask pod logs in the database."""
+        pod_logs = None
+        session = None
 
-    @kopf.on.delete("v1", "pods", labels={"dask.org/component": "scheduler"})
-    @kopf.on.delete("v1", "pods", labels={"dask.org/component": "worker"})
-    def on_pod_delete(name, meta, patch, namespace, logger, **_):
-        """Retrieve logs before a Dask-labeled pod is deleted."""
         try:
             logger.info(f"Fetching logs for pod: {name} in namespace: {namespace}")
             pod_logs = current_k8s_corev1_api_client.read_namespaced_pod_log(
@@ -58,34 +47,141 @@ if not REANA_OPENSEARCH_ENABLED:
                 workflow_id, "database_model_service"
             )
             component_name = extract_component_name_from_pod_name(name)
+            pod_uid = meta.get("uid")
 
-            # Create a new service log entry
             service = session.query(Service).filter_by(name=service_name).first()
-            if service and pod_logs:
-                service_log = ServiceLog(
-                    service_id=service.id_,
-                    log={
-                        "component": component_name,
-                        "content": pod_logs,
-                    },
-                )
-                session.add(service_log)
-                session.commit()
-                logger.info(f"Successfully stored logs for pod {name}")
-            else:
+            if not service or not pod_logs:
                 logger.warning(
-                    f"Could not store logs - service {service_name} not found or no logs available"
+                    f"Could not store logs: service {service_name} not found or no logs available"
                 )
+                return
+
+            # Deduplicate repeated resume or delete events only when the same pod UID is seen again
+            if pod_uid and any(
+                (stored.log or {}).get("pod_uid") == pod_uid for stored in service.logs
+            ):
+                logger.info(
+                    f"Logs for pod {name} already stored for service {service_name}"
+                )
+                return
+
+            service_log = ServiceLog(
+                service_id=service.id_,
+                log={
+                    "component": component_name,
+                    "pod": name,
+                    "pod_uid": pod_uid,
+                    "content": pod_logs,
+                },
+            )
+            session.add(service_log)
+            session.commit()
+            logger.info(f"Successfully stored logs for pod {name}")
         except Exception as e:
+            if session:
+                session.rollback()
             logger.error(f"Error writing pod logs to DB {name}: {e}")
+        finally:
+            if session:
+                session.close()
+
+    def _remove_finalizer(name, meta, namespace, logger):
+        """Remove the custom pod finalizer to let deletion proceed."""
+        finalizers = meta.get("finalizers", [])
+        if DASK_PODS_FINALIZER_NAME not in finalizers:
+            return
+
+        remaining_finalizers = [f for f in finalizers if f != DASK_PODS_FINALIZER_NAME]
+        logger.info(f"Removing finalizer from {name}")
 
         try:
-            finalizers = meta.get("finalizers", [])
-            if DASK_PODS_FINALIZER_NAME in finalizers:
-                logger.info(f"Removing finalizer from {name}")
-                patch.metadata["finalizers"] = [
-                    f for f in finalizers if f != DASK_PODS_FINALIZER_NAME
-                ]
-
+            current_k8s_corev1_api_client.patch_namespaced_pod(
+                name=name,
+                namespace=namespace,
+                body=(
+                    [
+                        {
+                            "op": "replace",
+                            "path": "/metadata/finalizers",
+                            "value": remaining_finalizers,
+                        }
+                    ]
+                    if remaining_finalizers
+                    else [{"op": "remove", "path": "/metadata/finalizers"}]
+                ),
+            )
+        except ApiException as e:
+            if e.status == 404:
+                logger.info(f"Pod {name} no longer exists while removing finalizer.")
+                return
+            logger.error(f"Error removing finalizer from {name}: {e}")
+            raise kopf.TemporaryError(
+                f"Could not remove finalizer from pod {name}.", delay=5
+            ) from e
         except Exception as e:
             logger.error(f"Error removing finalizer from {name}: {e}")
+            raise kopf.TemporaryError(
+                f"Could not remove finalizer from pod {name}.", delay=5
+            ) from e
+
+    @kopf.on.create("v1", "pods", labels={"dask.org/component": "scheduler"})
+    @kopf.on.resume(
+        "v1",
+        "pods",
+        labels={"dask.org/component": "scheduler"},
+        deleted=False,
+    )
+    @kopf.on.create("v1", "pods", labels={"dask.org/component": "worker"})
+    @kopf.on.resume(
+        "v1",
+        "pods",
+        labels={"dask.org/component": "worker"},
+        deleted=False,
+    )
+    def add_finalizer(name, meta, patch, logger, **_):
+        """Ensure the custom finalizer is present on Dask pods."""
+        try:
+            if meta.get("deletionTimestamp"):
+                return
+
+            logger.info(f"Adding finalizer to pod {name}")
+            finalizers = meta.get("finalizers", [])
+            if DASK_PODS_FINALIZER_NAME not in finalizers:
+                finalizers.append(DASK_PODS_FINALIZER_NAME)
+                patch.metadata["finalizers"] = finalizers
+        except Exception as e:
+            logger.error(f"Error adding finalizer to pod {name}: {e}")
+
+    @kopf.on.event("v1", "pods", labels={"dask.org/component": "scheduler"})
+    @kopf.on.resume(
+        "v1",
+        "pods",
+        labels={"dask.org/component": "scheduler"},
+        deleted=True,
+    )
+    @kopf.on.event("v1", "pods", labels={"dask.org/component": "worker"})
+    @kopf.on.resume(
+        "v1",
+        "pods",
+        labels={"dask.org/component": "worker"},
+        deleted=True,
+    )
+    def on_pod_terminating(name, meta, namespace, logger, **_):
+        """Retrieve logs when a Dask pod starts terminating."""
+        if not meta.get("deletionTimestamp"):
+            return
+
+        if DASK_PODS_FINALIZER_NAME not in meta.get("finalizers", []):
+            return
+
+        try:
+            _store_pod_logs(name=name, meta=meta, namespace=namespace, logger=logger)
+        except Exception as e:
+            logger.error(f"Unexpected error while storing logs for pod {name}: {e}")
+        finally:
+            _remove_finalizer(
+                name=name,
+                meta=meta,
+                namespace=namespace,
+                logger=logger,
+            )


### PR DESCRIPTION
Store Dask pod logs when pods enter the terminating state before removing the custom finalizer and skip duplicate inserts on resume.

Closes reanahub/reana-ui#493