### PR TITLE
ci(run-tests): correct package name for pydocstyle and docker

### DIFF
--- a/reana_dask_kubernetes_operator/utils.py
+++ b/reana_dask_kubernetes_operator/utils.py
@@ -10,8 +10,7 @@
 
 
 def extract_component_name_from_pod_name(pod_name: str) -> str | None:
-    """Extracts a component name from the pod name."""
-
+    """Extract a component name from the pod name."""
     if "worker" in pod_name:
         return pod_name[pod_name.index("worker") :]
     elif "scheduler" in pod_name:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,7 +10,7 @@ set -o errexit
 set -o nounset
 
 docker_build() {
-    docker build -t docker.io/reanahub/reana-workflow-engine-serial .
+    docker build -t docker.io/reanahub/reana-dask-kubernetes-operator .
 }
 
 format_black() {
@@ -84,7 +84,7 @@ lint_markdownlint() {
 }
 
 lint_pydocstyle() {
-    pydocstyle reana_workflow_engine_serial
+    pydocstyle reana_dask_kubernetes_operator
 }
 
 lint_shellcheck() {


### PR DESCRIPTION
The lint and docker-build targets were wrongly referring to reana-workflow-engine-serial (perhaps due to a past copy/paste), so pydocstyle was silently linting a non-existent directory and exiting green. Point them at the actual package and fix the two pre-existing D202/D401 violations in utils.py that surface once the lint is correctly scoped.