### PR TITLE
fix(git): update .gitignore to exclude modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ target/
 
 # Visual Studio Code files
 .vscode
+
+# REANA modules for local development
+modules/

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,5 +2,6 @@
 
 The list of contributors in alphabetical order:
 
+- [Alexander Sohn](https://orcid.org/0009-0000-3673-4637)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Tibor Simko](https://orcid.org/0000-0001-7202-5803)


### PR DESCRIPTION
For local development we populate the modules directory with the local version of reana-commons, so changes to this component are reflected everywhere. This leads to a lot of untracked files, which can be confusing for new developers.

Fixes reanahub/reana#963