### PR TITLE
ci(triggers): drop scheduled workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,7 @@
 
 name: ci
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 7 * * 1"
+on: [push, pull_request]
 
 jobs:
   docker-build:


### PR DESCRIPTION
Remove the weekly cron trigger from the CI workflow.

The workflow now runs only for pushes and pull requests, matching
the regular repository-activity based CI pattern.
